### PR TITLE
SearchResults gereset bij een nieuwe zoekopdracht

### DIFF
--- a/recipes.js
+++ b/recipes.js
@@ -3,8 +3,9 @@ $(document).ready(function () {
         $.ajax({
             url: `https://api.spoonacular.com/recipes/complexSearch?query=${$('#searchValue').val()}&apiKey=c25e2d349ba842ee8186ded1ff30b942`
         }).done(function (data) {
+            const searchResults = document.querySelector('.searchResults');
+            searchResults.innerHTML = "";
             data.results.forEach(recipe => {
-                const searchResults = document.querySelector('.searchResults');
 
                 const newItem = document.createElement('div');
                 newItem.classList.add('recipe');


### PR DESCRIPTION
SearchResults gereset bij elke nieuwe zoekopdracht om de issue "Geen reset na zoeken recepten" op te lossen.
Hiervoor de variabele searchresults buiten de loop gezet