### PR TITLE
Clear recipe list when attempting to search again

### DIFF
--- a/recipes.js
+++ b/recipes.js
@@ -3,9 +3,9 @@ $(document).ready(function () {
         $.ajax({
             url: `https://api.spoonacular.com/recipes/complexSearch?query=${$('#searchValue').val()}&apiKey=c25e2d349ba842ee8186ded1ff30b942`
         }).done(function (data) {
+            const searchResults = document.querySelector('.searchResults');
+            searchResults.innerHTML = "";
             data.results.forEach(recipe => {
-                const searchResults = document.querySelector('.searchResults');
-
                 const newItem = document.createElement('div');
                 newItem.classList.add('recipe');
                 newItem.innerHTML = `<h3>${recipe.title}</h3><a href="ingredients.html?id=${recipe.id}"><img src=${recipe.image} /></a>`;


### PR DESCRIPTION
Fix issue christian-graafschap/SpoonaculairCodeDemo#1.

When searching for recipes the recipe.html the previous result was never cleared. This PR clears this.